### PR TITLE
version 1.1.0a2: `JSONExportableRootDict()` BREAKING CHANGES

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-exportables"
-version = "1.1.0a1"
+version = "1.1.0a2"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Python Pydantic BaseModel extension and helpers for easier import/export to different formats (JSON, CSV, TXT)"
 readme = "README.md"

--- a/src/pydantic_exportables/__init__.py
+++ b/src/pydantic_exportables/__init__.py
@@ -3,6 +3,7 @@ from .jsonexportable import (
     JSONExportable as JSONExportable,
     JSONExportableRootDict as JSONExportableRootDict,
     PyObjectId as PyObjectId,
+    validate_object_id as validate_object_id,
     TypeExcludeDict as TypeExcludeDict,
     IndexSortOrder as IndexSortOrder,
     BackendIndex as BackendIndex,

--- a/src/pydantic_exportables/jsonexportable.py
+++ b/src/pydantic_exportables/jsonexportable.py
@@ -248,18 +248,19 @@ class JSONExportable(BaseModel):
             params["exclude_defaults"] = False
             params["exclude_unset"] = False
             params["exclude_none"] = False
-        elif "exclude" in kwargs:
-            try:
-                params["exclude"].update(kwargs["exclude"])
-                del kwargs["exclude"]
-            except Exception:
-                pass
-        elif "include" in kwargs:
-            try:
-                params["include"].update(kwargs["include"])
-                del kwargs["include"]
-            except Exception:
-                pass
+        else:
+            if "exclude" in kwargs:
+                try:
+                    params["exclude"].update(kwargs["exclude"])
+                    del kwargs["exclude"]
+                except Exception as err:
+                    debug(f"'exclude' caused an error: {err}")
+            if "include" in kwargs:
+                try:
+                    params["include"].update(kwargs["include"])
+                    del kwargs["include"]
+                except Exception as err:
+                    debug(f"'include' caused an error: {err}")
         params.update(kwargs)
         return params
 

--- a/tests/test_pyobjectid.py
+++ b/tests/test_pyobjectid.py
@@ -1,0 +1,48 @@
+import pytest  # type: ignore
+
+from bson import ObjectId
+from typing import List
+
+from pydantic_exportables import PyObjectId, validate_object_id
+
+
+@pytest.fixture
+def object_ids() -> List[PyObjectId]:
+    return [ObjectId() for _ in range(10)]
+
+
+@pytest.fixture
+def object_id_strs_ok() -> List[str]:
+    return [str(ObjectId()) for _ in range(10)]
+
+
+@pytest.fixture
+def object_id_strs_nok() -> List[str]:
+    return (
+        [str(ObjectId())[3:-1] for _ in range(4)]
+        + [str(ObjectId()) + "SHOULD_FAIL" for _ in range(4)]
+        + ["Thzsz orz not HEX -1"]
+    )
+
+
+def test_1_PyObjectId(object_ids: List[PyObjectId]):
+    for object_id in object_ids:
+        assert isinstance(
+            validate_object_id(object_id), ObjectId
+        ), f"could not validate a valid ObjectId: {str(object_id)}"
+
+
+def test_2_validate_object_id_str_OK(object_id_strs_ok: List[str]):
+    for object_id_str in object_id_strs_ok:
+        assert isinstance(
+            validate_object_id(object_id_str), ObjectId
+        ), f"could not validate a valid ObjectId string: {object_id_str}"
+
+
+def test_3_validate_object_id_str_FAIL(object_id_strs_nok: List[str]):
+    for object_id_str in object_id_strs_nok:
+        try:
+            validate_object_id(object_id_str)
+            assert False, f"validated an invalida ObjectId string: {object_id_str}"
+        except ValueError:
+            pass

--- a/tests/test_pyobjectid.py
+++ b/tests/test_pyobjectid.py
@@ -3,7 +3,10 @@ import pytest  # type: ignore
 from bson import ObjectId
 from typing import List
 
-from pydantic_exportables import PyObjectId, validate_object_id
+from pydantic_exportables import (
+    PyObjectId,
+    validate_object_id,
+)
 
 
 @pytest.fixture


### PR DESCRIPTION
- `JSONExportableRootDict()`: do not inherit from `JSONExportable()`
- Increased test coverage