### PR TITLE
version version 1.1.0a7: FIX `JSONExportableRootDict()` key validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-exportables"
-version = "1.1.0a6"
+version = "1.1.0a7"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Python Pydantic BaseModel extension and helpers for easier import/export to different formats (JSON, CSV, TXT)"
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pydantic-exportables"
-version = "1.1.0a5"
+version = "1.1.0a6"
 authors = [{ name = "Jylpah", email = "jylpah@gmail.com" }]
 description = "Python Pydantic BaseModel extension and helpers for easier import/export to different formats (JSON, CSV, TXT)"
 readme = "README.md"

--- a/src/pydantic_exportables/jsonexportable.py
+++ b/src/pydantic_exportables/jsonexportable.py
@@ -33,6 +33,7 @@ from pydantic import (
     ValidationError,
     ConfigDict,
     Field,
+    model_validator,
     # InstanceOf,
     # PlainSerializer,
     # AfterValidator,
@@ -396,6 +397,14 @@ class JSONExportableRootDict(
         populate_by_name=True,
         from_attributes=True,
     )
+
+    @model_validator(mode='after')
+    def validate_keys(self) -> Self:
+        new_root: Dict[Idx, JSONExportableType] = dict()
+        for value in self.root.values():
+            new_root[value.index] = value
+        self.__dict__["root"] = new_root        
+        return self
 
     def add(self, item: JSONExportableType) -> None:
         self.root[item.index] = item

--- a/src/pydantic_exportables/jsonexportable.py
+++ b/src/pydantic_exportables/jsonexportable.py
@@ -33,7 +33,7 @@ from pydantic import (
     ValidationError,
     ConfigDict,
     Field,
-    model_validator,
+    # model_validator,
     # InstanceOf,
     # PlainSerializer,
     # AfterValidator,
@@ -48,24 +48,6 @@ from bson import ObjectId
 from pyutils.utils import str2path
 
 from .pyobjectid import PyObjectId
-
-# BaseModel.model_config["json_encoders"] = {ObjectId: lambda v: str(v)}
-
-# def validate_object_id(v: Any) -> ObjectId:
-#     if isinstance(v, ObjectId):
-#         return v
-#     if ObjectId.is_valid(v):
-#         return ObjectId(v)
-#     raise ValueError("Invalid ObjectId")
-
-
-# PyObjectId = Annotated[
-#     InstanceOf[ObjectId],
-#     # Union[str, ObjectId],
-#     AfterValidator(validate_object_id),
-#     PlainSerializer(lambda x: str(x), return_type=str),
-#     WithJsonSchema({"type": "string"}, mode="serialization"),
-# ]
 
 
 TypeExcludeDict = MutableMapping[int | str, Any]
@@ -566,76 +548,7 @@ class JSONExportableRootDict(
     def parse_str(cls, content: str) -> Self | None:
         """return class instance from a JSON string"""
         try:
-            ## WORKAROUND for https://github.com/pydantic/pydantic/issues/8189#issuecomment-1823465499
             return cls.model_validate_json(content)
-            # return cls.model_validate(json.loads(content), strict=True)
         except ValueError as err:
             debug(f"Could not parse {type(cls)} from JSON: {err}")
         return None
-
-    # def model_dump(  # type: ignore
-    #     self,
-    #     *,
-    #     mode: str = "python",
-    #     include: Any = None,
-    #     exclude: Any = None,
-    #     by_alias: bool = False,
-    #     exclude_unset: bool = False,
-    #     exclude_defaults: bool = False,
-    #     exclude_none: bool = False,
-    #     round_trip: bool = False,
-    #     warnings: bool = True,
-    # ) -> Dict[str | int, Any]:
-    #     res: Dict[str | int, Any] = dict()
-    #     for key, value in self.items():
-    #         _key: str | int
-    #         if isinstance(key, ObjectId):
-    #             _key = str(key)
-    #         else:
-    #             _key = key
-    #         res[_key] = value.model_dump(
-    #             mode=mode,
-    #             include=include,
-    #             exclude=exclude,
-    #             by_alias=by_alias,
-    #             exclude_unset=exclude_unset,
-    #             exclude_defaults=exclude_defaults,
-    #             exclude_none=exclude_none,
-    #             round_trip=round_trip,
-    #             warnings=warnings,
-    #         )
-    #     return res
-
-
-# class Map(JSONExportable):
-#     name: str
-#     code: PyObjectId
-#     id: int = Field(default=2)
-
-#     _exclude_defaults = True
-
-#     @property
-#     def index(self) -> PyObjectId:
-#         return self.code
-
-
-# class Maps(JSONExportableRootDict[Map]):
-#     model_config = ConfigDict(
-#         frozen=False,
-#         validate_assignment=True,
-#         populate_by_name=True,
-#         from_attributes=True,
-#     )
-
-
-# maps = Maps()
-
-# for i in range(5):
-#     maps.add(Map(name=f"test {i}", code=ObjectId(), id=i))
-
-
-# print(maps.json_db())
-
-
-# class TestClass(JSONExportable):
-#     data: Maps = Field(default_factory=Maps)

--- a/src/pydantic_exportables/jsonexportable.py
+++ b/src/pydantic_exportables/jsonexportable.py
@@ -94,6 +94,7 @@ class JSONExportable(BaseModel):
 
     model_config = ConfigDict(
         frozen=False,
+        revalidate_instances="always",
         validate_assignment=True,
         populate_by_name=True,
         from_attributes=True,
@@ -378,6 +379,7 @@ class JSONExportableRootDict(
         validate_assignment=True,
         populate_by_name=True,
         from_attributes=True,
+        revalidate_instances="always",
     )
 
     @model_validator(mode='after')

--- a/src/pydantic_exportables/jsonexportable.py
+++ b/src/pydantic_exportables/jsonexportable.py
@@ -382,13 +382,13 @@ class JSONExportableRootDict(
         revalidate_instances="always",
     )
 
-    @model_validator(mode='after')
-    def validate_keys(self) -> Self:
-        new_root: Dict[Idx, JSONExportableType] = dict()
-        for value in self.root.values():
-            new_root[value.index] = value
-        self.__dict__["root"] = new_root        
-        return self
+    # @model_validator(mode="after")
+    # def validate_keys(self) -> Self:
+    #     new_root: Dict[Idx, JSONExportableType] = dict()
+    #     for value in self.root.values():
+    #         new_root[value.index] = value
+    #     self.__dict__["root"] = new_root
+    #     return self
 
     def add(self, item: JSONExportableType) -> None:
         self.root[item.index] = item

--- a/src/pydantic_exportables/pyobjectid.py
+++ b/src/pydantic_exportables/pyobjectid.py
@@ -1,3 +1,6 @@
+## Copyright PhilJay, 2023
+# source https://stackoverflow.com/a/77105412
+
 from typing import Any
 from bson import ObjectId
 from pydantic_core import core_schema

--- a/src/pydantic_exportables/pyobjectid.py
+++ b/src/pydantic_exportables/pyobjectid.py
@@ -3,35 +3,66 @@
 
 from typing import Any
 from bson import ObjectId
-from pydantic_core import core_schema
+from pydantic_core import core_schema, CoreSchema
+from pydantic import (
+    GetCoreSchemaHandler,
+    GetJsonSchemaHandler,
+)
+from pydantic.json_schema import JsonSchemaValue
+
+# class PyObjectId(str):
+#     @classmethod
+#     def __get_pydantic_core_schema__(
+#         cls, _source_type: Any, _handler: Any
+#     ) -> core_schema.CoreSchema:
+#         return core_schema.json_or_python_schema(
+#             json_schema=core_schema.str_schema(),
+#             python_schema=core_schema.union_schema(
+#                 [
+#                     core_schema.is_instance_schema(ObjectId),
+#                     core_schema.chain_schema(
+#                         [
+#                             core_schema.str_schema(),
+#                             core_schema.no_info_plain_validator_function(cls.validate),
+#                         ]
+#                     ),
+#                 ]
+#             ),
+#             serialization=core_schema.plain_serializer_function_ser_schema(
+#                 lambda x: str(x)
+#             ),
+#         )
+
+#     @classmethod
+#     def validate(cls, value) -> ObjectId:
+#         if not ObjectId.is_valid(value):
+#             raise ValueError("Invalid ObjectId")
+
+#         return ObjectId(value)
 
 
-class PyObjectId(str):
+class PyObjectId(ObjectId):
+    """Wrapper for ObjectId"""
+
+    # https://stackoverflow.com/a/77101754/12946084
     @classmethod
     def __get_pydantic_core_schema__(
-        cls, _source_type: Any, _handler: Any
-    ) -> core_schema.CoreSchema:
-        return core_schema.json_or_python_schema(
-            json_schema=core_schema.str_schema(),
-            python_schema=core_schema.union_schema(
-                [
-                    core_schema.is_instance_schema(ObjectId),
-                    core_schema.chain_schema(
-                        [
-                            core_schema.str_schema(),
-                            core_schema.no_info_plain_validator_function(cls.validate),
-                        ]
-                    ),
-                ]
-            ),
-            serialization=core_schema.plain_serializer_function_ser_schema(
-                lambda x: str(x)
-            ),
+        cls,
+        _source_type: Any,
+        _handler: GetCoreSchemaHandler,
+    ) -> CoreSchema:
+        def validate(value: str) -> ObjectId:
+            if not ObjectId.is_valid(value):
+                raise ValueError("Invalid ObjectId")
+            return ObjectId(value)
+
+        return core_schema.no_info_plain_validator_function(
+            function=validate,
+            serialization=core_schema.to_string_ser_schema(),
         )
 
     @classmethod
-    def validate(cls, value) -> ObjectId:
-        if not ObjectId.is_valid(value):
-            raise ValueError("Invalid ObjectId")
-
-        return ObjectId(value)
+    def __get_pydantic_json_schema__(
+        cls, _core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        return handler(core_schema.str_schema())


### PR DESCRIPTION
- Solution was to give key type as another `Generic[]` param for the class
- FIX: `PyObjectId()` updated to get deserialization working